### PR TITLE
Add Redis caching and pagination for API endpoints

### DIFF
--- a/app/api/queries.py
+++ b/app/api/queries.py
@@ -1,195 +1,356 @@
 import logging
 import re
-
+import socket
 from datetime import datetime, timedelta
-
-from app.services import (
-    perform_live_scan
-)
-
-from app.api.utils import (
-    cache_key,
-    fetch_from_cache
-)
+from typing import Tuple
 
 from asyncio.log import logger
 
+from app.api.utils import cache_key, cached_paginated_fetch, paginate
+from app.services import asn_lookup, perform_live_scan
+
 logger.setLevel(logging.INFO)
 
+DEFAULT_CACHE_TTL = 300
 
-async def fetch_query_domain(mongo, domain: str):
+
+def _pagination_bounds(page: int, page_size: int) -> Tuple[int, int]:
+    safe_page = max(page, 1)
+    safe_page_size = max(page_size, 1)
+    skip = (safe_page - 1) * safe_page_size
+    return skip, safe_page_size
+
+
+async def fetch_query_domain(mongo, domain: str, page: int = 1, page_size: int = 25):
+    """Full text search across the DNS collection with caching and pagination."""
+
     sub_query = domain.lower()
     query = {"$text": {"$search": domain}}
-    filter = {"_id": 0}
-    sort = {"score": {"$meta": "textScore"}}
-    limit = 30
-    context = "text"
-    return await fetch_from_cache(
-        mongo,
-        query=query,
-        filter=filter,
-        unwind=False,
-        sort=sort,
-        limit=limit,
-        context=context,
-        reset=False,
-        cache_key_str=f"all-{cache_key(sub_query)}",
+    projection = {"_id": 0, "score": {"$meta": "textScore"}}
+    skip, limit = _pagination_bounds(page, page_size)
+
+    async def loader():
+        cursor = mongo.dns.find(query, projection).sort(
+            [("score", {"$meta": "textScore"}), ("updated", -1)]
+        )
+        if skip:
+            cursor = cursor.skip(skip)
+        cursor = cursor.limit(limit)
+
+        results = await cursor.to_list(length=limit)
+        total = await mongo.dns.count_documents(query)
+        return results, total
+
+    key = f"query:{cache_key(sub_query)}:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
     )
 
 
-async def fetch_all_prefix(mongo, prefix: str):
-    cursor = mongo.lookup.find({'cidr': {'$in': [prefix]}}, {'_id': 0})
-    return await cursor.to_list(length=100)
+async def fetch_all_prefix(mongo, prefix: str, page: int = 1, page_size: int = 25):
+    """Lookup CIDR prefixes from the cached subnet collection."""
+
+    query = {"cidr": {"$in": [prefix]}}
+    skip, limit = _pagination_bounds(page, page_size)
+
+    async def loader():
+        cursor = (
+            mongo.lookup.find(query, {"_id": 0})
+            .sort("_id", -1)
+            .skip(skip)
+            .limit(limit)
+        )
+        results = await cursor.to_list(length=limit)
+        total = await mongo.lookup.count_documents(query)
+        return results, total
+
+    key = f"subnet:{cache_key(prefix)}:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
+    )
 
 
 async def fetch_latest_dns(mongo, page: int = 1, page_size: int = 10):
+    """Return recently updated DNS documents with pagination."""
+
     date = datetime.now() - timedelta(days=1)
     query = {"updated": {"$gte": date}}
-    filter = {"_id": 0}
-    sort = {"updated": -1}
-    context = "normal"
-    skip = (page - 1) * page_size
+    skip, limit = _pagination_bounds(page, page_size)
 
-    results = await fetch_from_cache(
-        mongo,
-        query=query,
-        filter=filter,
-        unwind=False,
-        sort=sort,
-        limit=page_size,
-        skip=skip,
-        context=context,
-        reset=False,
-        cache_key_str=f"latest_dns_{page}_{page_size}",
+    async def loader():
+        cursor = (
+            mongo.dns.find(query, {"_id": 0})
+            .sort("updated", -1)
+            .skip(skip)
+            .limit(limit)
+        )
+        results = await cursor.to_list(length=limit)
+        total = await mongo.dns.count_documents(query)
+        return results, total
+
+    key = f"dns:latest:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
     )
 
-    return {"page": page, "page_size": page_size, "results": results}
 
+async def fetch_latest_cidr(mongo, page: int = 1, page_size: int = 50):
+    """Return the latest ASN CIDR ranges."""
 
-async def fetch_latest_cidr(mongo):
-    query = {'whois.asn_cidr': {'$exists': True}}
-    filter = {'_id': 0, 'whois.asn_country_code': 1, 'whois.asn_cidr': 1}
-    sort = {'updated': -1}
-    limit = 200
-    context = "normal"
-    return await fetch_from_cache(
-        mongo,
-        query,
-        filter,
-        unwind=False,
-        sort=sort,
-        limit=limit,
-        context=context,
-        reset=False,
-        cache_key_str="latest_cidr",
+    query = {"whois.asn_cidr": {"$exists": True}}
+    projection = {"_id": 0, "whois.asn_country_code": 1, "whois.asn_cidr": 1}
+    skip, limit = _pagination_bounds(page, page_size)
+
+    async def loader():
+        cursor = (
+            mongo.dns.find(query, projection)
+            .sort("updated", -1)
+            .skip(skip)
+            .limit(limit)
+        )
+        results = await cursor.to_list(length=limit)
+        total = await mongo.dns.count_documents(query)
+        return results, total
+
+    key = f"cidr:latest:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
     )
 
 
 async def fetch_latest_ipv4(mongo, page: int = 1, page_size: int = 60):
-    skip = (page - 1) * page_size
-    pipeline = [
-        {"$match": {"a_record": {"$exists": True, "$ne": []}}},
-        {"$sort": {"updated": -1}},
-        {"$skip": skip},
-        {"$limit": page_size},
-        {"$unwind": "$a_record"},
-        {"$project": {"_id": 0, "a_record": 1, "country_code": 1}}
-    ]
-    cursor = mongo.dns.aggregate(pipeline)
-    results = [doc async for doc in cursor]
-    return {"page": page, "page_size": page_size, "results": results}
+    """Return recent IPv4 records with pagination."""
 
+    match_stage = {"a_record": {"$exists": True, "$ne": []}}
+    skip, limit = _pagination_bounds(page, page_size)
 
-async def fetch_latest_asn(mongo):
-    query = {'whois.asn': {'$exists': True}}
-    filter = {'_id': 0, 'whois.asn': 1, 'whois.asn_country_code': 1}
-    sort = {'updated': -1}
-    limit = 200
-    context = "normal"
-    return await fetch_from_cache(
-        mongo,
-        query,
-        filter,
-        unwind=False,
-        sort=sort,
-        limit=limit,
-        context=context,
-        reset=False,
-        cache_key_str="latest_asn",
+    async def loader():
+        pipeline = [
+            {"$match": match_stage},
+            {"$unwind": "$a_record"},
+            {"$sort": {"updated": -1}},
+            {"$skip": skip},
+            {"$limit": limit},
+            {"$project": {"_id": 0, "a_record": 1, "country_code": 1}},
+        ]
+        cursor = mongo.dns.aggregate(pipeline)
+        results = [doc async for doc in cursor]
+
+        count_cursor = mongo.dns.aggregate(
+            [
+                {"$match": match_stage},
+                {"$unwind": "$a_record"},
+                {"$count": "count"},
+            ]
+        )
+        count_docs = await count_cursor.to_list(length=1)
+        total = count_docs[0]["count"] if count_docs else 0
+        return results, total
+
+    key = f"ipv4:latest:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
     )
 
 
-async def fetch_one_ip(mongo, ip: str):
-    cursor = mongo.dns.find({'a_record': {'$in': [ip]}}, {'_id': 0})
-    return await cursor.to_list(length=1)
+async def fetch_latest_asn(mongo, page: int = 1, page_size: int = 50):
+    """Return the most recently seen ASNs."""
+
+    query = {"whois.asn": {"$exists": True}}
+    projection = {"_id": 0, "whois.asn": 1, "whois.asn_country_code": 1}
+    skip, limit = _pagination_bounds(page, page_size)
+
+    async def loader():
+        cursor = (
+            mongo.dns.find(query, projection)
+            .sort("updated", -1)
+            .skip(skip)
+            .limit(limit)
+        )
+        results = await cursor.to_list(length=limit)
+        total = await mongo.dns.count_documents(query)
+        return results, total
+
+    key = f"asn:latest:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
+    )
 
 
-async def extract_graph(db, domain):
-    """
-    Same logic as before, just moved here for graph queries.
-    """
-    cursor = db.dns.aggregate([
-        {'$match': {'domain': domain}},
-        {'$graphLookup': {
-            'from': 'dns',
-            'startWith': '$ssl.subject_alt_names',
-            'connectFromField': 'domain',
-            'connectToField': 'ssl.subject_alt_names',
-            'as': 'certificates'
-        }},
-        {'$graphLookup': {
-            'from': 'dns',
-            'startWith': '$cname_record.target',
-            'connectFromField': 'domain',
-            'connectToField': 'cname_record.target',
-            'as': 'cname_records'
-        }},
-        {'$graphLookup': {
-            'from': 'dns',
-            'startWith': '$mx_record.exchange',
-            'connectFromField': 'mx_record.exchange',
-            'connectToField': 'domain',
-            'as': 'mx_records'
-        }},
-        {'$graphLookup': {
-            'from': 'dns',
-            'startWith': '$ns_record',
-            'connectFromField': 'ns_record',
-            'connectToField': 'domain',
-            'as': 'ns_records'
-        }},
-        {'$project': {
-            'main.domain': '$domain',
-            'main.a_record': '$a_record',
-            'zzz': {'$setUnion': [
-                '$certificates', '$cname_records', '$mx_records', '$ns_records'
-            ]}
-        }},
-        {'$unwind': '$zzz'},
-        {'$group': {
-            '_id': '$_id',
-            'main': {'$addToSet': '$main'},
-            'all': {'$addToSet': '$zzz'}
-        }},
-        {'$project': {
-            'all.domain': 1,
-            'all.a_record': 1,
-            'main': 1,
-            '_id': 0
-        }}
-    ])
-    return await cursor.to_list(length=None)
+async def _build_ip_fallback(mongo, ip: str) -> dict:
+    """Construct a fallback record for IP lookups when Mongo has no entry."""
+
+    lookup = asn_lookup(ip)
+    try:
+        host = socket.gethostbyaddr(ip)[0]
+    except Exception:  # noqa: BLE001 - best effort reverse lookup
+        host = None
+
+    now = datetime.now()
+    record = {
+        "ip": ip,
+        "host": host,
+        "updated": now,
+        "asn": lookup.get("asn"),
+        "name": lookup.get("name"),
+        "cidr": [lookup.get("prefix")],
+    }
+
+    try:
+        await mongo.lookup.update_one({"ip": ip}, {"$set": record}, upsert=True)
+    except Exception:  # noqa: BLE001 - cache insert best effort
+        pass
+
+    return record
 
 
-async def fetch_match_condition(mongo, condition: str, query: str):
+async def fetch_one_ip(mongo, ip: str, page: int = 1, page_size: int = 1):
+    """Return paginated information for a specific IPv4 address."""
+
+    query = {"a_record": {"$in": [ip]}}
+    projection = {"_id": 0}
+    skip, limit = _pagination_bounds(page, page_size)
+
+    async def loader():
+        cursor = mongo.dns.find(query, projection).sort("updated", -1)
+        if skip:
+            cursor = cursor.skip(skip)
+        cursor = cursor.limit(limit)
+
+        results = await cursor.to_list(length=limit)
+        total = await mongo.dns.count_documents(query)
+
+        if not results and page == 1:
+            logger.info("Falling back to live ASN lookup for %s", ip)
+            results = [await _build_ip_fallback(mongo, ip)]
+            total = 1
+
+        return results, total
+
+    key = f"ip:{ip}:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
+    )
+
+
+async def extract_graph(db, domain: str, page: int = 1, page_size: int = 50):
+    """Return a graph of related DNS entities for a given domain."""
+
+    pipeline = [
+        {"$match": {"domain": domain}},
+        {
+            "$graphLookup": {
+                "from": "dns",
+                "startWith": "$ssl.subject_alt_names",
+                "connectFromField": "domain",
+                "connectToField": "ssl.subject_alt_names",
+                "as": "certificates",
+            }
+        },
+        {
+            "$graphLookup": {
+                "from": "dns",
+                "startWith": "$cname_record.target",
+                "connectFromField": "domain",
+                "connectToField": "cname_record.target",
+                "as": "cname_records",
+            }
+        },
+        {
+            "$graphLookup": {
+                "from": "dns",
+                "startWith": "$mx_record.exchange",
+                "connectFromField": "mx_record.exchange",
+                "connectToField": "domain",
+                "as": "mx_records",
+            }
+        },
+        {
+            "$graphLookup": {
+                "from": "dns",
+                "startWith": "$ns_record",
+                "connectFromField": "ns_record",
+                "connectToField": "domain",
+                "as": "ns_records",
+            }
+        },
+        {
+            "$project": {
+                "main.domain": "$domain",
+                "main.a_record": "$a_record",
+                "zzz": {
+                    "$setUnion": ["$certificates", "$cname_records", "$mx_records", "$ns_records"]
+                },
+            }
+        },
+        {"$unwind": "$zzz"},
+        {"$group": {"_id": "$_id", "main": {"$addToSet": "$main"}, "all": {"$addToSet": "$zzz"}}},
+        {"$project": {"all.domain": 1, "all.a_record": 1, "main": 1, "_id": 0}},
+    ]
+
+    skip, limit = _pagination_bounds(page, page_size)
+
+    async def loader():
+        cursor = db.dns.aggregate(pipeline)
+        docs = [doc async for doc in cursor]
+        total = len(docs)
+        start = min(skip, total)
+        end = min(start + limit, total)
+        return docs[start:end], total
+
+    key = f"graph:{cache_key(domain.lower())}:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
+    )
+
+
+async def fetch_match_condition(
+    mongo,
+    condition: str,
+    query: str,
+    page: int = 1,
+    page_size: int = 30,
+):
+    """Dispatch match queries with pagination and Redis caching."""
+
     if not query:
-        return []
-
-    print(f"Fetching condition: {condition} with query: {query}")
+        return paginate(page=page, page_size=page_size, total=0, results=[])
 
     condition = condition.lower()
+    logger.info("Fetching condition: %s with query: %s", condition, query)
 
-    # Normalizers
     sub_query = query.lower()
     if condition == "country":
         sub_query = query.upper()
@@ -200,10 +361,7 @@ async def fetch_match_condition(mongo, condition: str, query: str):
             return {
                 "geo.loc": {
                     "$nearSphere": {
-                        "$geometry": {
-                            "type": "Point",
-                            "coordinates": [lat, lon]
-                        },
+                        "$geometry": {"type": "Point", "coordinates": [lat, lon]},
                         "$maxDistance": 50000,
                     }
                 }
@@ -211,7 +369,6 @@ async def fetch_match_condition(mongo, condition: str, query: str):
         except ValueError:
             return {}
 
-    # Dispatcher map
     condition_map = {
         "registry": lambda q: {"whois.asn_registry": q},
         "port": lambda q: {"ports.port": int(q)},
@@ -222,37 +379,30 @@ async def fetch_match_condition(mongo, condition: str, query: str):
                 {"ssl.subject_alt_names": {"$in": [q]}},
             ]
         },
-        "before": lambda q: {
-            "ssl.not_before": {
-                "$gte": datetime.strptime(q, "%Y-%m-%d %H:%M:%S")
-            }
-        },
-        "after": lambda q: {
-            "ssl.not_after": {
-                "$lte": datetime.strptime(q, "%Y-%m-%d %H:%M:%S")
-            }
-        },
+        "before": lambda q: {"ssl.not_before": {"$gte": datetime.strptime(q, "%Y-%m-%d %H:%M:%S")}},
+        "after": lambda q: {"ssl.not_after": {"$lte": datetime.strptime(q, "%Y-%m-%d %H:%M:%S")}},
         "ca": lambda q: {"ssl.ca_issuers": q},
-        "issuer": lambda q: {"$or": [
-            {"ssl.issuer.organization_name": q},
-            {"ssl.issuer.common_name": q}
-        ]},
-        "unit": lambda q: {"$or": [
-            {"ssl.issuer.organizational_unit_name": q},
-            {"ssl.subject.organizational_unit_name": q}
-        ]},
+        "issuer": lambda q: {
+            "$or": [
+                {"ssl.issuer.organization_name": q},
+                {"ssl.issuer.common_name": q},
+            ]
+        },
+        "unit": lambda q: {
+            "$or": [
+                {"ssl.issuer.organizational_unit_name": q},
+                {"ssl.subject.organizational_unit_name": q},
+            ]
+        },
         "ocsp": lambda q: {"ssl.ocsp": q},
         "crl": lambda q: {"ssl.crl_distribution_points": q},
         "service": lambda q: {"header.x-powered-by": q},
-        "country": lambda q: {"$or": [
-            {"geo.country_code": q},
-            {"whois.asn_country_code": q}
-        ]},
+        "country": lambda q: {"$or": [{"geo.country_code": q}, {"whois.asn_country_code": q}]},
         "state": lambda q: {
             "$expr": {
                 "$regexMatch": {
                     "input": {"$toLower": "$geo.state"},
-                    "regex": q.lower()
+                    "regex": q.lower(),
                 }
             }
         },
@@ -260,7 +410,7 @@ async def fetch_match_condition(mongo, condition: str, query: str):
             "$expr": {
                 "$regexMatch": {
                     "input": {"$toLower": "$geo.city"},
-                    "regex": q.lower()
+                    "regex": q.lower(),
                 }
             }
         },
@@ -269,7 +419,7 @@ async def fetch_match_condition(mongo, condition: str, query: str):
             "$expr": {
                 "$regexMatch": {
                     "input": {"$toLower": "$banner"},
-                    "regex": q.lower()
+                    "regex": q.lower(),
                 }
             }
         },
@@ -280,20 +430,18 @@ async def fetch_match_condition(mongo, condition: str, query: str):
                     "$expr": {
                         "$regexMatch": {
                             "input": {"$toLower": "$whois.asn_description"},
-                            "regex": q.lower()
+                            "regex": q.lower(),
                         }
                     }
                 },
                 {
                     "$expr": {
                         "$regexMatch": {
-                            "input": {
-                                "$toLower": "$ssl.subject.organization_name"
-                            },
-                            "regex": q.lower()
+                            "input": {"$toLower": "$ssl.subject.organization_name"},
+                            "regex": q.lower(),
                         }
                     }
-                }
+                },
             ]
         },
         "cidr": lambda q: {"whois.asn_cidr": q},
@@ -304,7 +452,7 @@ async def fetch_match_condition(mongo, condition: str, query: str):
             "$expr": {
                 "$regexMatch": {
                     "input": {"$toLower": "$header.server"},
-                    "regex": q.lower()
+                    "regex": q.lower(),
                 }
             }
         },
@@ -313,30 +461,43 @@ async def fetch_match_condition(mongo, condition: str, query: str):
         "ipv6": lambda q: {"aaaa_record": {"$in": [q]}},
     }
 
-    # Build query
     builder = condition_map.get(condition)
-    print(f"Using builder for condition: {condition}")
+    logger.info("Using builder for condition: %s", condition)
     if not builder:
-        return []
+        return paginate(page=page, page_size=page_size, total=0, results=[])
 
     mongo_query = builder(sub_query)
-    print(f"MongoDB Query: {mongo_query}")
+    if not mongo_query:
+        return paginate(page=page, page_size=page_size, total=0, results=[])
+    logger.info("MongoDB Query: %s", mongo_query)
+    skip, limit = _pagination_bounds(page, page_size)
 
-    cursor = mongo.dns.find(mongo_query, {"_id": 0}).sort(
-        "updated", -1).limit(30)
-    results = await cursor.to_list(length=30)
-    print(f"Found {len(results)} results in DB for condition: {condition}")
-    
-    only_domains = bool(results) and all(
-        isinstance(doc.get("a_record"), list) and len(doc["a_record"]) >= 1
-        for doc in results
+    async def loader():
+        cursor = mongo.dns.find(mongo_query, {"_id": 0}).sort("updated", -1)
+        if skip:
+            cursor = cursor.skip(skip)
+        cursor = cursor.limit(limit)
+        results = await cursor.to_list(length=limit)
+        total = await mongo.dns.count_documents(mongo_query)
+
+        only_domains = bool(results) and all(
+            isinstance(doc.get("a_record"), list) and len(doc["a_record"]) >= 1
+            for doc in results
+        )
+
+        if (not results or not only_domains) and condition in {"site", "domain"} and page == 1:
+            logger.info("Running live scan fallback for %s", query)
+            results = [await perform_live_scan(mongo, query)]
+            total = 1
+
+        logger.info("Returning %s results for condition %s", len(results), condition)
+        return results, total
+
+    key = f"match:{condition}:{cache_key(sub_query)}:{page}:{page_size}"
+    return await cached_paginated_fetch(
+        key,
+        loader,
+        page=page,
+        page_size=page_size,
+        ttl=DEFAULT_CACHE_TTL,
     )
-    
-    print(only_domains)
-
-    # Fallback live-scan if nothing OR only bare domains
-    # (keep your condition guard)
-    if (not results or not only_domains) and condition in ["site", "domain"]:
-        return [await perform_live_scan(mongo, query)]
-
-    return results

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,12 +1,64 @@
-import aiocache
+from typing import Awaitable, Callable, TypeVar
 
-cache = aiocache.Cache(aiocache.SimpleMemoryCache)
+from aiocache import Cache
+from aiocache.serializers import PickleSerializer
 
-async def fetch_from_cache(key: str, fetch_func, *args, ttl: int = 60, **kwargs):
-    """Check cache first; if miss, fetch and store."""
-    val = await cache.get(key)
-    if val is not None:
-        return val
-    val = await fetch_func(*args, **kwargs)
-    await cache.set(key, val, ttl=ttl)
-    return val
+from app.config import (
+    CACHE_EXPIRE,
+    REDIS_DB,
+    REDIS_HOST,
+    REDIS_NAMESPACE,
+    REDIS_PASSWORD,
+    REDIS_PORT,
+)
+
+T = TypeVar("T")
+
+
+cache = Cache(
+    Cache.REDIS,
+    endpoint=REDIS_HOST,
+    port=REDIS_PORT,
+    password=REDIS_PASSWORD,
+    db=REDIS_DB,
+    namespace=REDIS_NAMESPACE,
+    serializer=PickleSerializer(),
+)
+
+
+async def fetch_from_cache(
+    key: str,
+    fetch_func: Callable[[], Awaitable[T]],
+    *,
+    ttl: int = CACHE_EXPIRE,
+    refresh: bool = False,
+) -> T:
+    """Retrieve ``key`` from Redis or compute it with ``fetch_func``.
+
+    Parameters
+    ----------
+    key:
+        Cache key to look up.
+    fetch_func:
+        Zero-argument coroutine that computes the value when there is a cache miss.
+    ttl:
+        Time-to-live for the cached value in seconds.
+    refresh:
+        When ``True`` the value is recomputed and the cache is updated regardless
+        of an existing entry.
+    """
+
+    if not refresh:
+        cached = await cache.get(key)
+        if cached is not None:
+            return cached
+
+    value = await fetch_func()
+    await cache.set(key, value, ttl=ttl)
+    return value
+
+
+async def invalidate_cache(key: str) -> None:
+    """Remove ``key`` from the shared Redis cache if it exists."""
+
+    await cache.delete(key)

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 # Paths
@@ -7,10 +8,20 @@ ASN_DB = DATA_DIR / "rib.20250901.1600.dat"
 ASN_NAMES = DATA_DIR / "asn_names.json"
 
 # Defaults
-CACHE_EXPIRE = 86400
-MASSCAN_RATE = 1000
-SOCKET_TIMEOUT = 3
+CACHE_EXPIRE = int(os.getenv("CACHE_EXPIRE", "86400"))
+MASSCAN_RATE = int(os.getenv("MASSCAN_RATE", "1000"))
+SOCKET_TIMEOUT = int(os.getenv("SOCKET_TIMEOUT", "3"))
+
+# Redis cache configuration
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+REDIS_DB = int(os.getenv("REDIS_DB", "0"))
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD") or None
+REDIS_NAMESPACE = os.getenv("REDIS_NAMESPACE", "purple_jo")
+
+DEFAULT_PAGE_SIZE = int(os.getenv("DEFAULT_PAGE_SIZE", "25"))
+MAX_PAGE_SIZE = int(os.getenv("MAX_PAGE_SIZE", "200"))
 
 
-MONGO_URI = "mongodb://localhost:27017"
-DB_NAME = "ip_data"
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = os.getenv("DB_NAME", "ip_data")

--- a/app/routes/asn.py
+++ b/app/routes/asn.py
@@ -1,13 +1,19 @@
-from fastapi import APIRouter, HTTPException, Depends
-from app.api import fetch_latest_asn
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from app.api import fetch_latest_asn
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 router = APIRouter()
 
 @router.get("/asn")
-async def latest_asn(mongo: AsyncIOMotorDatabase = Depends(get_mongo)):
-    items = await fetch_latest_asn(mongo)
-    if items:
+async def latest_asn(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
+):
+    items = await fetch_latest_asn(mongo, page=page, page_size=page_size)
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/cidr.py
+++ b/app/routes/cidr.py
@@ -1,14 +1,20 @@
-from fastapi import APIRouter, HTTPException, Depends
-from app.api import fetch_latest_cidr
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from app.api import fetch_latest_cidr
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 router = APIRouter()
 
 
 @router.get("/cidr")
-async def latest_cidr(mongo: AsyncIOMotorDatabase = Depends(get_mongo)):
-    items = await fetch_latest_cidr(mongo)
-    if items:
+async def latest_cidr(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
+):
+    items = await fetch_latest_cidr(mongo, page=page, page_size=page_size)
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/dns.py
+++ b/app/routes/dns.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, Query, Depends
-from app.api import fetch_latest_dns
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from app.api import fetch_latest_dns
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 
@@ -10,10 +12,10 @@ router = APIRouter()
 @router.get("/dns")
 async def latest_dns(
     page: int = Query(1, ge=1),
-    page_size: int = Query(10, ge=1, le=100),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     mongo: AsyncIOMotorDatabase = Depends(get_mongo)
 ):
     items = await fetch_latest_dns(mongo, page=page, page_size=page_size)
-    if items and items.get("results"):
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/graph.py
+++ b/app/routes/graph.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, Depends
-from app.api import extract_graph
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from app.api import extract_graph
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 
@@ -8,8 +10,13 @@ router = APIRouter()
 
 
 @router.get("/graph/{site}")
-async def graph(site: str, mongo: AsyncIOMotorDatabase = Depends(get_mongo)):
-    items = await extract_graph(mongo, site)
-    if items:
+async def graph(
+    site: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
+):
+    items = await extract_graph(mongo, site, page=page, page_size=page_size)
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/ip.py
+++ b/app/routes/ip.py
@@ -1,43 +1,22 @@
-import socket
-from datetime import datetime
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
-from app.api import fetch_one_ip, asn_lookup
-from app.responses import MongoJSONResponse
+
+from app.api import fetch_one_ip
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
+from app.responses import MongoJSONResponse
 
 router = APIRouter()
 
 @router.get("/ip/{ipv4}", response_class=MongoJSONResponse)
 async def ip_lookup(
     ipv4: str,
-    mongo: AsyncIOMotorDatabase = Depends(get_mongo)
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
 ):
-    items = await fetch_one_ip(mongo, ipv4)
-    if not items:
-        res = asn_lookup(ipv4)
-        try:
-            host = socket.gethostbyaddr(ipv4)[0]
-        except Exception:
-            host = None
-
-        prop = {
-            "ip": ipv4,
-            "host": host,
-            "updated": datetime.now(),
-            "asn": res["asn"],
-            "name": res["name"],
-            "cidr": [res["prefix"]],
-        }
-
-        try:
-            await mongo.lookup.insert_one(prop)
-        except Exception:
-            pass
-
-        items = [prop]
-
-    if items:
-        return MongoJSONResponse(items)
+    items = await fetch_one_ip(mongo, ipv4, page=page, page_size=page_size)
+    if items.get("results"):
+        return items
 
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/ipv4.py
+++ b/app/routes/ipv4.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, HTTPException, Depends
-from app.api import fetch_latest_ipv4
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from app.api import fetch_latest_ipv4
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 
@@ -8,8 +10,12 @@ router = APIRouter()
 
 
 @router.get("/ipv4")
-async def latest_ipv4(mongo: AsyncIOMotorDatabase = Depends(get_mongo)):
-    items = await fetch_latest_ipv4(mongo)
-    if items and items.get("results"):
+async def latest_ipv4(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
+):
+    items = await fetch_latest_ipv4(mongo, page=page, page_size=page_size)
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/query.py
+++ b/app/routes/query.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
+
 from app.api import fetch_query_domain
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 router = APIRouter()
@@ -9,9 +11,11 @@ router = APIRouter()
 @router.get("/query/{domain}")
 async def query_domain(
     domain: str,
-    mongo: AsyncIOMotorDatabase = Depends(get_mongo)
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
 ):
-    items = await fetch_query_domain(mongo, domain)
-    if items:
+    items = await fetch_query_domain(mongo, domain, page=page, page_size=page_size)
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/subnet.py
+++ b/app/routes/subnet.py
@@ -1,12 +1,27 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
 from app.api import fetch_all_prefix
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from app.deps import get_mongo
 
 router = APIRouter()
 
 
 @router.get("/subnet/{sub}/{prefix}")
-async def subnet(sub: str, prefix: str, mongo=...):
-    items = await fetch_all_prefix(mongo, f"{sub}/{prefix}")
-    if items:
+async def subnet(
+    sub: str,
+    prefix: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    mongo: AsyncIOMotorDatabase = Depends(get_mongo),
+):
+    items = await fetch_all_prefix(
+        mongo,
+        f"{sub}/{prefix}",
+        page=page,
+        page_size=page_size,
+    )
+    if items.get("results"):
         return items
     raise HTTPException(status_code=404, detail="No documents found")

--- a/app/routes/trends.py
+++ b/app/routes/trends.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
 
 from app.api import fetch_request_trends
+from app.config import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.deps import get_mongo
 
 
@@ -18,6 +19,8 @@ async def request_trends(
     top_paths: int = Query(5, ge=0, le=50),
     recent_limit: int = Query(20, ge=0, le=100),
     path: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     mongo: AsyncIOMotorDatabase = Depends(get_mongo),
 ):
     """Return aggregated request trends for the API."""
@@ -30,4 +33,6 @@ async def request_trends(
         top_paths=top_paths,
         recent_limit=recent_limit,
         path=path,
+        page=page,
+        page_size=page_size,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ typing_extensions==4.15.0
 urllib3==2.5.0
 uvicorn==0.35.0
 yarl==1.20.1
+redis==5.1.1


### PR DESCRIPTION
## Summary
- configure Redis-backed caching and expose pagination helpers for consistent responses
- refactor API query and trend fetchers to return paginated payloads backed by Redis
- wire pagination query params through every route and add Redis dependency

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68ca684fd5688323931cffd185ce9b60