### PR TITLE
Bootstrap tools scripts for standalone execution

### DIFF
--- a/tools/bootstrap.py
+++ b/tools/bootstrap.py
@@ -1,0 +1,25 @@
+"""Utility helpers to bootstrap standalone execution of tools scripts."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Final
+
+_PROJECT_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+
+if __name__ == "tools.bootstrap":  # pragma: no cover - alias for script imports
+    sys.modules.setdefault("bootstrap", sys.modules[__name__])
+else:  # pragma: no cover - alias for module imports
+    sys.modules.setdefault("tools.bootstrap", sys.modules[__name__])
+
+
+def setup() -> Path:
+    """Ensure the project root is available on ``sys.path`` and return it."""
+    project_root = _PROJECT_ROOT
+    project_root_str = str(project_root)
+    if project_root_str not in sys.path:
+        sys.path.insert(0, project_root_str)
+    return project_root
+
+
+__all__ = ["setup"]

--- a/tools/crawl_urls_postgres.py
+++ b/tools/crawl_urls_postgres.py
@@ -7,7 +7,15 @@ Maintains the same high-throughput architecture while using the new database bac
 """
 
 from __future__ import annotations
-from app.models.postgres import CrawlStatus, Domain, Url
+
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
 
 import asyncio
 import contextlib
@@ -33,8 +41,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-# Add the project root to the Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from app.models.postgres import CrawlStatus, Domain, Url
 
 
 log = logging.getLogger(__name__)

--- a/tools/dns_publisher_service.py
+++ b/tools/dns_publisher_service.py
@@ -8,6 +8,15 @@ It queries the database for unprocessed domains and feeds them to worker service
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import logging
 import os
@@ -18,9 +27,6 @@ import aio_pika
 import click
 from aio_pika import DeliveryMode, Message
 from sqlmodel import select, func
-
-# Add the project root to the Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import Domain, ARecord  # noqa: E402
 

--- a/tools/dns_shared.py
+++ b/tools/dns_shared.py
@@ -6,6 +6,15 @@ Common components used by both the DNS worker service and publisher service.
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import logging
 import os
@@ -23,9 +32,6 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-# Add the project root to the Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import (  # noqa: E402
     Domain, ARecord, AAAARecord, NSRecord, MXRecord,

--- a/tools/dns_worker_service.py
+++ b/tools/dns_worker_service.py
@@ -9,6 +9,15 @@ names from a queue and performs DNS record extraction.
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import logging
 import os
@@ -22,9 +31,6 @@ import aio_pika
 import click
 from aio_pika import DeliveryMode, Message
 from aiormq.exceptions import AMQPConnectionError
-
-# Add the project root to the Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import (  # noqa: E402
     Domain, ARecord, AAAARecord, NSRecord, MXRecord,

--- a/tools/extract_certstream.py
+++ b/tools/extract_certstream.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
 """Certificate Transparency log monitor for PostgreSQL domain extraction."""
 
+from __future__ import annotations
+
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import logging
 import os
@@ -15,9 +26,6 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import Domain
 

--- a/tools/extract_domains.py
+++ b/tools/extract_domains.py
@@ -1,23 +1,31 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import re
-import time
+from __future__ import annotations
+
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
+import asyncio
 import math
 import multiprocessing
-import asyncio
+import re
 import sys
-import click
+import time
 from datetime import datetime, UTC
-from pathlib import Path
 
-# Add the project root to the Python path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
+import click
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
+
 from app.models.postgres import Domain, Url
 
 

--- a/tools/extract_geoip.py
+++ b/tools/extract_geoip.py
@@ -9,6 +9,15 @@ failure markers on success.
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import contextlib
 import json
@@ -32,9 +41,6 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-# Add the project root to the Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import Domain, GeoPoint, ARecord  # noqa: E402
 

--- a/tools/extract_records.py
+++ b/tools/extract_records.py
@@ -14,6 +14,15 @@ dns_worker_service.py instead of this coordinator script.
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import contextlib
 import logging
@@ -36,9 +45,6 @@ from dns.resolver import NoAnswer, NoNameservers, NXDOMAIN
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlmodel import select, func
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-# Add the project root to the Python path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import (  # noqa: E402
     Domain, ARecord, AAAARecord, NSRecord, MXRecord,

--- a/tools/migrate_mongo_to_postgres.py
+++ b/tools/migrate_mongo_to_postgres.py
@@ -2,22 +2,26 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import argparse
 import asyncio
 import logging
-from datetime import datetime, timezone
-from typing import Any, Iterable, Optional
-
 import os
 import sys
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
 
 from motor.motor_asyncio import AsyncIOMotorClient
 from sqlalchemy import delete, select
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if ROOT_DIR not in sys.path:
-    sys.path.insert(0, ROOT_DIR)
 
 from app.db_postgres import get_session_factory, init_db
 from app.models.postgres import (

--- a/tools/migrate_urls_schema.py
+++ b/tools/migrate_urls_schema.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""
-Migration script to add domain_extracted column to urls table.
+"""Migration script to add domain_extracted column to urls table."""
 
-This script adds the domain_extracted column needed for the extract_domains.py tool.
-"""
+from __future__ import annotations
+
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
 
 import asyncio
 import sys
-from pathlib import Path
-
-# Add the project root to the Python path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import click
 from sqlalchemy import text

--- a/tools/ssl_cert_scanner.py
+++ b/tools/ssl_cert_scanner.py
@@ -3,6 +3,15 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+
+try:
+    import bootstrap  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for module execution
+    bootstrap = import_module("tools.bootstrap")
+
+bootstrap.setup()
+
 import asyncio
 import contextlib
 import logging
@@ -24,9 +33,6 @@ import click
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
-
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.models.postgres import Domain, PortService, SSLData, SSLSubjectAltName
 


### PR DESCRIPTION
## Summary
- add a reusable bootstrap helper to expose the project root on sys.path for standalone tools
- update crawler, DNS, extraction, and migration scripts to import the bootstrap helper instead of hard-coded path tweaks

## Testing
- python tools/crawl_urls_postgres.py --help
- python tools/dns_worker_service.py --help
- python tools/extract_domains.py --help
- python tools/migrate_urls_schema.py --help

------
https://chatgpt.com/codex/tasks/task_e_68da8d1e451c8323ad77a414f9a9ee27