### PR TITLE
Add TXT DNS record extraction

### DIFF
--- a/app/services/dns.py
+++ b/app/services/dns.py
@@ -39,4 +39,10 @@ async def fetch_dns_records(domain: str) -> dict:
     except Exception:
         pass
 
+    try:
+        txt_record = await resolver.query(domain, "TXT")
+        records["txt_record"] = [r.text for r in txt_record]
+    except Exception:
+        pass
+
     return records


### PR DESCRIPTION
## Summary
- extend DNS record fetching to include TXT records
- capture TXT responses via the aiodns resolver

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db7f403f6483238f9f135d77475b66