### PR TITLE
Fix AsyncSession.exec call for batch updates

### DIFF
--- a/tools/banner_grabber.py
+++ b/tools/banner_grabber.py
@@ -243,7 +243,7 @@ async def persist_batch_results(
                         updated_at=bindparam("updated_at"),
                     )
                 )
-                await session.exec(stmt, params)
+                await session.exec(stmt, params=params)
 
                 state_stmt = insert(BannerScanState).values(
                     [


### PR DESCRIPTION
## Summary
- fix the TypeError raised when persisting banner scan successes by passing parameters to `AsyncSession.exec` as keyword arguments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd0e6857c83239d5dd0ec0710321b