### PR TITLE
Fix banner grabber bulk update session sync

### DIFF
--- a/tools/banner_grabber.py
+++ b/tools/banner_grabber.py
@@ -242,6 +242,7 @@ async def persist_batch_results(
                         banner=bindparam("banner"),
                         updated_at=bindparam("updated_at"),
                     )
+                    .execution_options(synchronize_session=False)
                 )
                 await session.exec(stmt, params=params)
 


### PR DESCRIPTION
## Summary
- add synchronize_session execution option to the bulk update used by the banner grabber
- prevent SQLAlchemy InvalidRequestError when persisting banner results

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd1fb416c8323a6787a564ef27f28