### PR TITLE
Fix banner update bind parameter

### DIFF
--- a/tools/banner_grabber.py
+++ b/tools/banner_grabber.py
@@ -222,7 +222,7 @@ async def persist_batch_results(
             if successes:
                 params = [
                     {
-                        "id": domain_id,
+                        "domain_id_bind": domain_id,
                         "domain_id": domain_id,
                         "banner": banner,
                         "updated_at": now,
@@ -231,7 +231,7 @@ async def persist_batch_results(
                 ]
                 stmt = (
                     update(Domain)
-                    .where(Domain.id == bindparam("id"))
+                    .where(Domain.id == bindparam("domain_id_bind"))
                     .values(
                         banner=bindparam("banner"),
                         updated_at=bindparam("updated_at"),


### PR DESCRIPTION
## Summary
- rename the domain update bind parameter so SQLAlchemy no longer rejects bulk updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd4b049f88323a16d6d472dc72f5d