### PR TITLE
Fix pending domain query order for header extractor

### DIFF
--- a/tools/extract_header.py
+++ b/tools/extract_header.py
@@ -186,7 +186,6 @@ def _pending_domains_select() -> Select:
         .where(Domain.header_content_type.is_(None))
         .where(Domain.header_status.is_(None))
         .where(HeaderScanState.header_scan_failed.is_(None))
-        .distinct()
     )
 
 


### PR DESCRIPTION
## Summary
- remove the redundant DISTINCT clause from the pending domain query so ORDER BY columns are valid for PostgreSQL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce338202c83239ab8fd981935c0b0