### PR TITLE
Refactor tooling workflows into class-based orchestrators

### DIFF
--- a/tools/decode_idna.py
+++ b/tools/decode_idna.py
@@ -16,91 +16,112 @@ try:
     from tool_runner import CLITool
 except ModuleNotFoundError:
     from tools.tool_runner import CLITool
+class IDNADecoder:
+    """Decode IDNA-encoded domains stored in PostgreSQL."""
 
+    @staticmethod
+    def utcnow() -> datetime:
+        """Return a naive UTC timestamp compatible with PostgreSQL columns."""
 
-def utcnow() -> datetime:
-    """Return a naive UTC timestamp compatible with PostgreSQL columns."""
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+        return datetime.now(timezone.utc).replace(tzinfo=None)
 
+    @classmethod
+    async def create_postgres_pool(cls, dsn: str) -> asyncpg.Pool:
+        """Create a PostgreSQL connection pool."""
 
-async def create_postgres_pool(dsn: str) -> asyncpg.Pool:
-    """Create a PostgreSQL connection pool."""
-    return await asyncpg.create_pool(asyncpg_pool_dsn(dsn))
+        return await asyncpg.create_pool(asyncpg_pool_dsn(dsn))
 
+    @classmethod
+    async def retrieve_idna_domains(cls, pool: asyncpg.Pool) -> List[Tuple[int, str]]:
+        """Retrieve domains containing IDNA encoding (xn--) from PostgreSQL."""
 
-async def retrieve_idna_domains(pool: asyncpg.Pool) -> List[Tuple[int, str]]:
-    """Retrieve domains containing IDNA encoding (xn--) from PostgreSQL."""
-    async with pool.acquire() as conn:
-        try:
-            # Find domains that contain IDNA encoding patterns
-            query = """
-                SELECT id, name
-                FROM domains
-                WHERE name ~ '(^|[.])(xn--)[a-z0-9]+'
-                ORDER BY id
-            """
-            rows = await conn.fetch(query)
-            return [(row['id'], row['name']) for row in rows]
-        except Exception as e:
-            print(f"[ERROR] Failed to retrieve IDNA domains: {e}")
-            return []
-
-
-async def update_domain_name(pool: asyncpg.Pool, domain_id: int,
-                             original_name: str, decoded_name: str) -> None:
-    """Update domain name with decoded IDNA version."""
-    async with pool.acquire() as conn:
-        try:
-            now = utcnow()
-            result = await conn.execute("""
-                UPDATE domains
-                SET name = $1, updated_at = $2
-                WHERE id = $3
-            """, decoded_name, now, domain_id)
-
-            if result == "UPDATE 1":
-                msg = f'INFO: Updated domain {original_name} -> {decoded_name}'
-                print(msg)
-            else:
-                print(f'WARNING: Failed to update domain ID {domain_id}')
-        except Exception as e:
-            print(f"ERROR: Failed to update domain {original_name}: {e}")
-
-
-async def process_idna_domains(postgres_dsn: str) -> None:
-    """Process IDNA domains and decode them."""
-    pool = await create_postgres_pool(postgres_dsn)
-
-    try:
-        # Retrieve domains with IDNA encoding
-        domains = await retrieve_idna_domains(pool)
-
-        if not domains:
-            click.echo("[INFO] No IDNA-encoded domains found")
-            return
-
-        click.echo(f"[INFO] Found {len(domains)} IDNA-encoded domains")
-
-        decoded_count = 0
-        for domain_id, idna_domain in domains:
+        async with pool.acquire() as conn:
             try:
-                # Attempt to decode IDNA domain
-                decoded_domain = idna.decode(idna_domain)
+                # Find domains that contain IDNA encoding patterns
+                query = """
+                    SELECT id, name
+                    FROM domains
+                    WHERE name ~ '(^|[.])(xn--)[a-z0-9]+'
+                    ORDER BY id
+                """
+                rows = await conn.fetch(query)
+                return [(row['id'], row['name']) for row in rows]
+            except Exception as exc:  # noqa: BLE001
+                print(f"[ERROR] Failed to retrieve IDNA domains: {exc}")
+                return []
 
-                # Only update if decoding actually changed the domain
-                if decoded_domain and idna_domain != decoded_domain:
-                    await update_domain_name(pool, domain_id,
-                                             idna_domain, decoded_domain)
-                    decoded_count += 1
+    @classmethod
+    async def update_domain_name(
+        cls,
+        pool: asyncpg.Pool,
+        domain_id: int,
+        original_name: str,
+        decoded_name: str,
+    ) -> None:
+        """Update domain name with decoded IDNA version."""
 
-            except (UnicodeError, IDNAError) as e:
-                print(f"WARNING: Failed to decode {idna_domain}: {e}")
-                continue
+        async with pool.acquire() as conn:
+            try:
+                now = cls.utcnow()
+                result = await conn.execute(
+                    """
+                    UPDATE domains
+                    SET name = $1, updated_at = $2
+                    WHERE id = $3
+                    """,
+                    decoded_name,
+                    now,
+                    domain_id,
+                )
 
-        click.echo(f"[INFO] Successfully decoded {decoded_count} domains")
+                if result == "UPDATE 1":
+                    msg = f'INFO: Updated domain {original_name} -> {decoded_name}'
+                    print(msg)
+                else:
+                    print(f'WARNING: Failed to update domain ID {domain_id}')
+            except Exception as exc:  # noqa: BLE001
+                print(f"ERROR: Failed to update domain {original_name}: {exc}")
 
-    finally:
-        await pool.close()
+    @classmethod
+    async def process_idna_domains(cls, postgres_dsn: str) -> None:
+        """Process IDNA domains and decode them."""
+
+        pool = await cls.create_postgres_pool(postgres_dsn)
+
+        try:
+            # Retrieve domains with IDNA encoding
+            domains = await cls.retrieve_idna_domains(pool)
+
+            if not domains:
+                click.echo("[INFO] No IDNA-encoded domains found")
+                return
+
+            click.echo(f"[INFO] Found {len(domains)} IDNA-encoded domains")
+
+            decoded_count = 0
+            for domain_id, idna_domain in domains:
+                try:
+                    # Attempt to decode IDNA domain
+                    decoded_domain = idna.decode(idna_domain)
+
+                    # Only update if decoding actually changed the domain
+                    if decoded_domain and idna_domain != decoded_domain:
+                        await cls.update_domain_name(
+                            pool,
+                            domain_id,
+                            idna_domain,
+                            decoded_domain,
+                        )
+                        decoded_count += 1
+
+                except (UnicodeError, IDNAError) as exc:
+                    print(f"WARNING: Failed to decode {idna_domain}: {exc}")
+                    continue
+
+            click.echo(f"[INFO] Successfully decoded {decoded_count} domains")
+
+        finally:
+            await pool.close()
 
 
 @click.command()
@@ -118,7 +139,7 @@ def main(postgres_dsn: str):
     """
     click.echo("[INFO] Starting IDNA domain decoding")
 
-    asyncio.run(process_idna_domains(postgres_dsn))
+    asyncio.run(IDNADecoder.process_idna_domains(postgres_dsn))
 
 
 if __name__ == '__main__':

--- a/tools/extract_certstream.py
+++ b/tools/extract_certstream.py
@@ -80,50 +80,85 @@ class PostgresAsync:
         await self.engine.dispose()
 
 
-def create_callback(postgres_dsn: str):
-    """Create callback function with PostgreSQL connection."""
-    postgres = PostgresAsync(postgres_dsn)
-    
-    def print_callback(message, context):
-        """Process certificate transparency messages."""
-        logging.debug("Message -> {}".format(message))
+class CertstreamMonitor:
+    """Manage certificate stream ingestion."""
 
-        if message['message_type'] == "heartbeat":
-            return
+    @classmethod
+    def create_callback(cls, postgres_dsn: str):
+        """Create callback function with PostgreSQL connection."""
 
-        if message['message_type'] == "certificate_update":
-            all_domains = message['data']['leaf_cert']['all_domains']
+        postgres = PostgresAsync(postgres_dsn)
 
-            if len(all_domains) == 0:
+        def print_callback(message, context):
+            """Process certificate transparency messages."""
+
+            logging.debug("Message -> {}".format(message))
+
+            if message['message_type'] == "heartbeat":
                 return
 
-            # Process all domains from the certificate
-            for domain_name in all_domains:
-                if not domain_name:
-                    continue
-                    
-                # Remove wildcard prefix
-                domain_name = domain_name.replace('*.', '')
-                
-                # Skip invalid domains
-                if not domain_name or domain_name == "NULL":
-                    continue
-                
-                # Add domain asynchronously
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-                try:
-                    added = loop.run_until_complete(
-                        postgres.add_domain(domain_name)
-                    )
-                    if added:
-                        print(f"[NEW] {domain_name}")
-                    else:
-                        print(f"[EXISTS] {domain_name}")
-                finally:
-                    loop.close()
+            if message['message_type'] == "certificate_update":
+                all_domains = message['data']['leaf_cert']['all_domains']
 
-    return print_callback
+                if len(all_domains) == 0:
+                    return
+
+                # Process all domains from the certificate
+                for domain_name in all_domains:
+                    if not domain_name:
+                        continue
+
+                    # Remove wildcard prefix
+                    domain_name = domain_name.replace('*.', '')
+
+                    # Skip invalid domains
+                    if not domain_name or domain_name == "NULL":
+                        continue
+
+                    # Add domain asynchronously
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
+                    try:
+                        added = loop.run_until_complete(
+                            postgres.add_domain(domain_name)
+                        )
+                        if added:
+                            print(f"[NEW] {domain_name}")
+                        else:
+                            print(f"[EXISTS] {domain_name}")
+                    finally:
+                        loop.close()
+
+        return print_callback
+
+    @classmethod
+    def configure_logging(cls, verbose: bool) -> None:
+        """Configure module-level logging."""
+
+        log_level = logging.DEBUG if verbose else logging.INFO
+        logging.basicConfig(
+            format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s',
+            level=log_level,
+        )
+
+    @classmethod
+    def run(cls, postgres_dsn: str, verbose: bool) -> None:
+        """Start listening to the certificate stream."""
+
+        cls.configure_logging(verbose)
+
+        resolved_dsn = resolve_async_dsn(postgres_dsn)
+
+        click.echo("[INFO] Starting Certificate Transparency monitor...")
+        click.echo(f"[INFO] PostgreSQL DSN: {resolved_dsn}")
+
+        # Create callback with PostgreSQL connection
+        callback = cls.create_callback(resolved_dsn)
+
+        certstream.listen_for_events(
+            callback,
+            url='wss://certstream.calidog.io',
+        )
 
 
 @click.command()
@@ -140,25 +175,8 @@ def create_callback(postgres_dsn: str):
 )
 def main(postgres_dsn: str, verbose: bool):
     """Certificate Transparency log monitor for PostgreSQL."""
-    # Configure logging
-    log_level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s',
-        level=log_level
-    )
-
-    postgres_dsn = resolve_async_dsn(postgres_dsn)
-
-    click.echo("[INFO] Starting Certificate Transparency monitor...")
-    click.echo(f"[INFO] PostgreSQL DSN: {postgres_dsn}")
-    
-    # Create callback with PostgreSQL connection
-    callback = create_callback(postgres_dsn)
-    
     try:
-        certstream.listen_for_events(
-            callback, url='wss://certstream.calidog.io'
-        )
+        CertstreamMonitor.run(postgres_dsn, verbose)
     except KeyboardInterrupt:
         click.echo("\n[INFO] Stopping Certificate Transparency monitor...")
     except Exception as exc:

--- a/tools/generate_sitemap.py
+++ b/tools/generate_sitemap.py
@@ -19,81 +19,94 @@ from selenium.webdriver.common.by import By
 from lxml import etree
 
 
-def load_sitemap(filename):
-    with open(filename, 'r') as f:
-        return f.read()
+class SitemapGenerator:
+    """Generate sitemap files by crawling a target URL."""
 
+    @staticmethod
+    def load_sitemap(filename: str) -> str:
+        with open(filename, 'r') as handle:
+            return handle.read()
 
-def retrieve_sitemap(input):
-    xml = load_sitemap(input)
-    root = etree.XML(xml.encode())
-    sitemap = []
+    @classmethod
+    def retrieve_sitemap(cls, input_path: str) -> list[str]:
+        xml = cls.load_sitemap(input_path)
+        root = etree.XML(xml.encode())
+        sitemap: list[str] = []
 
-    for elm in root:
-        children = elm.getchildren()
-        loc = {'loc': children[0].text}
-        sitemap.append([loc])
+        for element in root:
+            children = element.getchildren()
+            sitemap.append(children[0].text)
 
-    return sitemap
+        return sitemap
 
+    @staticmethod
+    def create_sitemap(urls: set[str], output: str) -> None:
+        urlset = etree.Element('urlset')
+        urlset.attrib['xmlns'] = 'http://www.sitemaps.org/schemas/sitemap/0.9'
 
-def create_sitemap(urls, output):
-    urlset = etree.Element('urlset')
-    urlset.attrib['xmlns'] = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+        doc = etree.ElementTree(urlset)
 
-    doc = etree.ElementTree(urlset)
+        for uri in urls:
+            if uri is not None and (
+                uri.startswith('https://purplepee.co')
+                or uri.startswith('https://api.purplepee.co')
+            ):
+                url = etree.SubElement(urlset, 'url')
+                loc = etree.SubElement(url, 'loc')
+                loc.text = uri
 
-    for uri in urls:
-        if uri is not None and (uri.startswith('https://purplepee.co') or uri.startswith('https://api.purplepee.co')):
-            url = etree.SubElement(urlset, 'url')
-            loc = etree.SubElement(url, 'loc')
-            loc.text = uri
+        doc.write(output, xml_declaration=True, encoding='utf-8', pretty_print=True)
 
-    doc.write(output, xml_declaration=True, encoding='utf-8', pretty_print=True)
+    @staticmethod
+    def build_parser() -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--url', help='set url to scan', type=str, required=True)
+        parser.add_argument('--input', help='set sitemap file path', type=str)
+        return parser
 
+    @staticmethod
+    def configure_driver() -> webdriver.Chrome:
+        options = webdriver.ChromeOptions()
+        options.binary_location = '/usr/bin/chromium-browser'
+        options.add_argument('headless')
+        options.add_argument('disable-infobars')
+        options.add_argument('window-size=1200x800')
+        options.add_argument('start-maximized')
 
-def argparser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--url', help='set url to scan', type=str, required=True)
-    parser.add_argument('--input', help='set sitemap file path', type=str)
-    args = parser.parse_args()
+        driver = webdriver.Chrome(options=options)
+        driver.set_page_load_timeout(5)
+        return driver
 
-    return args
+    @classmethod
+    def run(cls) -> None:
+        args = cls.build_parser().parse_args()
+
+        driver = cls.configure_driver()
+
+        try:
+            driver.get(args.url)
+        except TimeoutException:
+            return
+
+        WebDriverWait(driver, 15).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, 'div#xhr'))
+        )
+
+        urls: set[str] = set()
+        for link in driver.find_elements(By.XPATH, '//a'):
+            urls.add(link.get_attribute('href'))
+
+        driver.close()
+
+        if args.input:
+            sitemap = cls.retrieve_sitemap(args.input)
+            urls.update(sitemap)
+
+            cls.create_sitemap(urls, args.input)
 
 
 def main():
-    args = argparser()
-
-    options = webdriver.ChromeOptions()
-    options.binary_location = '/usr/bin/chromium-browser'
-    options.add_argument('headless')
-    options.add_argument('disable-infobars')
-    options.add_argument('window-size=1200x800')
-    options.add_argument('start-maximized')
-
-    driver = webdriver.Chrome(options=options)
-    driver.set_page_load_timeout(5)
-
-    try:
-        driver.get(args.url)
-    except TimeoutException:
-        return
-
-    WebDriverWait(driver, 15).until(EC.presence_of_element_located((By.CSS_SELECTOR, 'div#xhr')))
-
-    urls = set()
-    for i in driver.find_elements(By.XPATH, '//a'):
-        urls.add(i.get_attribute('href'))
-
-    driver.close()
-
-    if args.input:
-        sitemap = retrieve_sitemap(args.input)
-
-        for site in sitemap:
-            urls.add(site[0]['loc'])
-
-    create_sitemap(urls, args.input)
+    SitemapGenerator.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- refactor multiple CLI scripts in tools/ to centralize orchestration logic into dedicated classes
- add reusable class methods to encapsulate database access, queue management, and worker coordination routines
- update main entry points to delegate execution to the new class-based structures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0a6cd9e483238db3465c5770d214